### PR TITLE
Use $DEVKITPRO env var to specify library search path

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,6 @@
 fn main() {
-    println!("cargo:rustc-link-search=native=/opt/devkitpro/libogc/lib/wii");
+    let dkp_path = std::env::var("DEVKITPRO").unwrap();
+
+    println!("cargo:rustc-link-search=native={}/libogc/lib/wii", dkp_path);
     println!("cargo:rustc-link-lib=static=ogc");
 }


### PR DESCRIPTION
This allows for the build script to run regardless of where the user installs devkitPPC